### PR TITLE
Updates for PR#614

### DIFF
--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -1700,7 +1700,7 @@
   type = real
   kind = kind_phys
 [fullradar_diag]
-  standard_name = flag_for_computing_full_radar_reflectivity
+  standard_name = do_full_radar_reflectivity
   long_name = flag for computing full radar reflectivity
   units = flag
   dimensions = ()

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -370,6 +370,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: clw_surf_ice(:)    => null()  !< RUC LSM: moist cloud water mixing ratio at surface over ice
     real (kind=kind_phys), pointer :: qwv_surf_land(:)   => null()  !< RUC LSM: water vapor mixing ratio at surface over land
     real (kind=kind_phys), pointer :: qwv_surf_ice(:)    => null()  !< RUC LSM: water vapor mixing ratio at surface over ice
+    real (kind=kind_phys), pointer :: rhofr(:)           => null()  !< RUC LSM: density of frozen precipitation
     real (kind=kind_phys), pointer :: tsnow_land(:)      => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over land
     real (kind=kind_phys), pointer :: tsnow_ice(:)       => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over ice
     real (kind=kind_phys), pointer :: snowfallac_land(:) => null()  !< ruc lsm diagnostics over land
@@ -2427,6 +2428,7 @@ module GFS_typedefs
        allocate (Sfcprop%clw_surf_ice    (IM))
        allocate (Sfcprop%qwv_surf_land   (IM))
        allocate (Sfcprop%qwv_surf_ice    (IM))
+       allocate (Sfcprop%rhofr           (IM))
        allocate (Sfcprop%tsnow_land      (IM))
        allocate (Sfcprop%tsnow_ice       (IM))
        allocate (Sfcprop%snowfallac_land (IM))
@@ -2442,6 +2444,7 @@ module GFS_typedefs
        Sfcprop%qwv_surf_land   = clear_val
        Sfcprop%qwv_surf_ice    = clear_val
        Sfcprop%flag_frsoil     = clear_val
+       Sfcprop%rhofr           = clear_val
        Sfcprop%tsnow_land      = clear_val
        Sfcprop%tsnow_ice       = clear_val
        Sfcprop%snowfallac_land = clear_val

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -4176,7 +4176,7 @@ module GFS_typedefs
     Model%use_ufo          = use_ufo
     Model%exticeden        = exticeden
     if (Model%exticeden .and. &
-      (Model%imp_physics /= Model%imp_physics_gfdl .and. Model%imp_physics /= Model%imp_physics_thompson .and. 
+      (Model%imp_physics /= Model%imp_physics_gfdl .and. Model%imp_physics /= Model%imp_physics_thompson .and. &
        Model%imp_physics /= Model%imp_physics_nssl )) then
       !see GFS_MP_generic_post.F90; exticeden is only compatible with GFDL, Thompson, or NSSL MP 
       print *,' Using exticeden = T is only valid when using GFDL, Thompson, or NSSL microphysics.'

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -4175,7 +4175,9 @@ module GFS_typedefs
     Model%isot             = isot
     Model%use_ufo          = use_ufo
     Model%exticeden        = exticeden
-    if (Model%exticeden .and. (imp_physics /= imp_physics_gfdl .and. imp_physics /= imp_physics_thompson .and. imp_physics /= imp_physics_nssl )) then
+    if (Model%exticeden .and. &
+      (Model%imp_physics /= Model%imp_physics_gfdl .and. Model%imp_physics /= Model%imp_physics_thompson .and. 
+       Model%imp_physics /= Model%imp_physics_nssl )) then
       !see GFS_MP_generic_post.F90; exticeden is only compatible with GFDL, Thompson, or NSSL MP 
       print *,' Using exticeden = T is only valid when using GFDL, Thompson, or NSSL microphysics.'
       stop

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -370,7 +370,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: clw_surf_ice(:)    => null()  !< RUC LSM: moist cloud water mixing ratio at surface over ice
     real (kind=kind_phys), pointer :: qwv_surf_land(:)   => null()  !< RUC LSM: water vapor mixing ratio at surface over land
     real (kind=kind_phys), pointer :: qwv_surf_ice(:)    => null()  !< RUC LSM: water vapor mixing ratio at surface over ice
-    real (kind=kind_phys), pointer :: rhofr(:)           => null()  !< RUC LSM: density of frozen precipitation
     real (kind=kind_phys), pointer :: tsnow_land(:)      => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over land
     real (kind=kind_phys), pointer :: tsnow_ice(:)       => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over ice
     real (kind=kind_phys), pointer :: snowfallac_land(:) => null()  !< ruc lsm diagnostics over land
@@ -2428,7 +2427,6 @@ module GFS_typedefs
        allocate (Sfcprop%clw_surf_ice    (IM))
        allocate (Sfcprop%qwv_surf_land   (IM))
        allocate (Sfcprop%qwv_surf_ice    (IM))
-       allocate (Sfcprop%rhofr           (IM))
        allocate (Sfcprop%tsnow_land      (IM))
        allocate (Sfcprop%tsnow_ice       (IM))
        allocate (Sfcprop%snowfallac_land (IM))
@@ -2444,7 +2442,6 @@ module GFS_typedefs
        Sfcprop%qwv_surf_land   = clear_val
        Sfcprop%qwv_surf_ice    = clear_val
        Sfcprop%flag_frsoil     = clear_val
-       Sfcprop%rhofr           = clear_val
        Sfcprop%tsnow_land      = clear_val
        Sfcprop%tsnow_ice       = clear_val
        Sfcprop%snowfallac_land = clear_val

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -7504,42 +7504,42 @@
   type = real
   kind = kind_phys
 [frzr]
-  standard_name = lwe_thickness_of_surface_freezing_rain_amount
+  standard_name = cumulative_lwe_thickness_of_surface_freezing_rain_amount
   long_name = accumulated surface freezing rain
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frzrb]
-  standard_name = lwe_thickness_of_surface_freezing_rain_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_freezing_rain_amount_in_bucket
   long_name = accumulated surface freezing rain in bucket
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frozr]
-  standard_name = lwe_thickness_of_surface_graupel_amount
+  standard_name = cumulative_lwe_thickness_of_surface_graupel_amount
   long_name = accumulated surface graupel
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frozrb]
-  standard_name = lwe_thickness_of_surface_graupel_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_graupel_amount_in_bucket
   long_name = accumulated surface graupel in bucket
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [tsnowp]
-  standard_name = lwe_thickness_of_surface_snow_amount
+  standard_name = cumulative_lwe_thickness_of_surface_snow_amount
   long_name = accumulated surface snow
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [tsnowpb]
-  standard_name = lwe_thickness_of_surface_snow_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_snow_amount_in_bucket
   long_name = accumulated surface snow in bucket
   units = m
   dimensions = (horizontal_loop_extent)

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1627,6 +1627,14 @@
   type = real
   kind = kind_phys
   active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
+[rhofr]
+  standard_name = lsm_internal_surface_frozen_precipitation_density
+  long_name = density of frozen precipitation
+  units = kg m-3
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tsnow_land]
   standard_name = temperature_in_surface_snow_at_surface_adjacent_layer_over_land
   long_name = snow temperature at the bottom of the first snow layer over land

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1627,14 +1627,6 @@
   type = real
   kind = kind_phys
   active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
-[rhofr]
-  standard_name = frozen_precipitation_density
-  long_name = density of frozen precipitation
-  units = kg m-3
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (control_for_land_surface_scheme == identifier_for_ruc_land_surface_scheme)
 [tsnow_land]
   standard_name = temperature_in_surface_snow_at_surface_adjacent_layer_over_land
   long_name = snow temperature at the bottom of the first snow layer over land
@@ -4171,7 +4163,7 @@
   dimensions = ()
   type = integer
 [vrbliceden_noah]
-  standard_name = flag_for_vrbl_prcp_ice_den
+  standard_name = do_variable_surface_frozen_precipitation_density
   long_name = flag for variable precip ice density
   units = flag
   dimensions = ()
@@ -7512,49 +7504,49 @@
   type = real
   kind = kind_phys
 [frzr]
-  standard_name = lwe_thickness_of_sfc_freezing_rain_amount
+  standard_name = lwe_thickness_of_surface_freezing_rain_amount
   long_name = accumulated surface freezing rain
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frzrb]
-  standard_name = lwe_thickness_of_sfc_freezing_rain_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_freezing_rain_amount_in_bucket
   long_name = accumulated surface freezing rain in bucket
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frozr]
-  standard_name = lwe_thickness_of_sfc_graupel_amount
+  standard_name = lwe_thickness_of_surface_graupel_amount
   long_name = accumulated surface graupel
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [frozrb]
-  standard_name = lwe_thickness_of_sfc_graupel_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_graupel_amount_in_bucket
   long_name = accumulated surface graupel in bucket
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [tsnowp]
-  standard_name = lwe_thickness_of_sfc_snow_amount
+  standard_name = lwe_thickness_of_surface_snow_amount
   long_name = accumulated surface snow
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [tsnowpb]
-  standard_name = lwe_thickness_of_sfc_snow_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_snow_amount_in_bucket
   long_name = accumulated surface snow in bucket
   units = m
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
 [rhonewsn1]
-  standard_name = lwe_density_of_precip_ice
+  standard_name = surface_frozen_precipitation_density
   long_name = density of precipitation ice
   units = kg m-3
   dimensions = (horizontal_loop_extent)

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -4170,9 +4170,9 @@
   units = count
   dimensions = ()
   type = integer
-[vrbliceden_noah]
-  standard_name = do_variable_surface_frozen_precipitation_density
-  long_name = flag for variable precip ice density
+[exticeden]
+  standard_name = do_external_surface_frozen_precipitation_density
+  long_name = flag for calculating frozen precip ice density outside of the LSM
   units = flag
   dimensions = ()
   type = logical


### PR DESCRIPTION
Changes:

- update CCPP standard names to match changes in https://github.com/ericaligo-NOAA/ccpp-physics/pull/1
- remove redundant frozen precipitation density variable only used in RUC LSM that is no longer necessary
- update atmos_cubed_sphere submodule pointer (was out-of-date and causing compilation failures)

@ericaligo-NOAA I'm running the RTs on Hera on Wed. evening. So far, compilation has succeeded, which means that my changes will have passed ccpp_prebuild.py and are OK.